### PR TITLE
Fixed wrong calls to free_func

### DIFF
--- a/vc_vector.c
+++ b/vc_vector.c
@@ -307,17 +307,9 @@ bool vc_vector_pop_back(vc_vector* vector) {
 }
 
 bool vc_vector_set(vc_vector* vector, size_t index, const void* value) {
-  if (unlikely(vector->free_func != NULL)) {
-    vector->free_func(vc_vector_at(vector, index));
-  }
-  
   return memcpy(vc_vector_at(vector, index), value, vector->element_size) != NULL;
 }
 
 bool vc_vector_set_multiple(vc_vector* vector, size_t index, const void* values, size_t count) {
-  if (unlikely(vector->free_func != NULL)) {
-    vc_vector_call_free_func(vector, index, index + count);
-  }
-  
   return memcpy(vc_vector_at(vector, index), values, vector->element_size * count) != NULL;
 }


### PR DESCRIPTION
vc_vector_set and vc_vector_set_multiple shouldn’t call free_func if
there is one because they will try to free pointers which were not
allocated.
Suppose you have a vector of pointers to char (a vector of variable
sized strings) and you insert elem at 0. insert calls vector_set and
vector_set will try to call free_func on vector_at(vector, 0), which
really is a free(\* (char *\* )s), but that doesn’t work since we never put
anything there in the first place. The same happens with append. Check test_vc_vector_with_strfreefunc to see an example and try it with and without the free_func calls. 
