### PR TITLE
Fix compilation warnings in library and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: c
 compiler:
   - gcc
+  - clang
 script:
-  - gcc vc_vector_test.c -o vc_vector_test.o -c -std=gnu99
-  - gcc vc_vector.c -o vc_vector.o -c -std=gnu99
-  - gcc -o test_runner vc_vector_test.o vc_vector.o
-  - ./test_runner
+  - make && make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+OUT_DIR := build
+CFLAGS := -O2 -g -std=c99 -Wall -Wextra -Wpedantic -Werror
+
+SRCS := $(wildcard *.c)
+OBJS := $(patsubst %.c,$(OUT_DIR)/%.o,$(SRCS))
+
+LIB_NAME := vc-vector
+SOBJ := $(OUT_DIR)/lib$(LIB_NAME).so
+
+.PHONY: all lib test clean
+
+all: lib
+
+lib: $(SOBJ)
+
+test: $(OUT_DIR)/test_runner
+	$(OUT_DIR)/test_runner
+
+clean:
+	rm -rf $(OUT_DIR)
+
+$(OUT_DIR):
+	mkdir -p $(OUT_DIR)
+
+$(SOBJ): vc_vector.c | $(OUT_DIR)
+	$(CC) $(CFLAGS) -shared -fPIC $< -o $@
+
+$(OUT_DIR)/%.o: %.c | $(OUT_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(OUT_DIR)/test_runner: $(OBJS) | $(OUT_DIR)
+	$(CC) $^ -o $@
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vc_vector
 Fast simple C vector implementation
 
-[![Build Status: gcc -std=gnu99](https://travis-ci.org/skogorev/vc_vector.svg)](https://travis-ci.org/skogorev/vc_vector)
+[![Build Status: make && make test](https://travis-ci.org/skogorev/vc_vector.svg)](https://travis-ci.org/skogorev/vc_vector)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fast simple C vector implementation
 
 ## Usage
 
-###Basic
+### Basic
 ```c
 #include "vc_vector.h"
 
@@ -36,7 +36,7 @@ int main() {
 }
 ```
 
-###Advanced
+### Advanced
 ```c
 #include "vc_vector.h"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Fast simple C vector implementation
 ## Usage
 
 ###Basic
-```
+```c
 #include "vc_vector.h"
 
 int main() {
@@ -37,7 +37,7 @@ int main() {
 ```
 
 ###Advanced
-```
+```c
 #include "vc_vector.h"
 
 struct Item {

--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ int main() {
   if (!v) {
     return 1;
   }
-  
+
   const int count = 10;
   for (int i = 0; i < count; ++i) {
     // The function takes a pointer to the elements,
     // but the vector will make a copy of the element
     vc_vector_push_back(v, &i);
   }
-  
+
   // Print each vector element
   for (void* i = vc_vector_begin(v);
              i != vc_vector_end(v);
              i = vc_vector_next(v, i)) {
     printf("%u; ", *(int*)i);
   }
-  
+
   vc_vector_release(v);
   return 0;
 }
@@ -47,14 +47,14 @@ struct Item {
 
 int main() {
   const int n = 10;
-  
+
   // Creates an empty vector with the reserved size for the 'n' elements
   // and with custom deleter 'free'. Vector will contain pointers to 'Item'
   vc_vector* v = vc_vector_create(n, sizeof(struct Node*), free);
   if (!v) {
     return 1;
   }
-  
+
   struct Item* item = NULL;
   const int count = n + 1;
   // Vector automatically increases the reserved size when 'n + 1' will be added
@@ -64,20 +64,20 @@ int main() {
     if (!item) {
       continue;
     }
-    
+
     item->val1 = i;
     item->val2 = 0;
-    
+
     // Pushing to the end of the vector
     if (!vc_vector_push_back(v, item)) {
       // If the item was not pushed, you have to delete it
       free(item);
     }
   }
-  
+
   // ...
 
-  // Calls custom deleter 'free' for all items 
+  // Calls custom deleter 'free' for all items
   // and releases the vector
   vc_vector_release(v);
   return 0;

--- a/vc_vector.c
+++ b/vc_vector.c
@@ -157,7 +157,7 @@ void* vc_vector_end(vc_vector* vector) {
 }
 
 void* vc_vector_next(vc_vector* vector, void* i) {
-  return i + vector->element_size;
+  return (char *)i + vector->element_size;
 }
 
 // ----------------------------------------------------------------------------

--- a/vc_vector.c
+++ b/vc_vector.c
@@ -28,7 +28,7 @@ bool vc_vector_realloc(vc_vector* vector, size_t new_count) {
   if (!new_data) {
     return false;
   }
-  
+
   vector->reserved_size = new_size;
   vector->data = new_data;
   return true;
@@ -56,11 +56,11 @@ vc_vector* vc_vector_create(size_t count_elements, size_t size_of_element, vc_ve
     v->count = 0;
     v->element_size = size_of_element;
     v->deleter = deleter;
-    
+
     if (count_elements < MINIMUM_COUNT_OF_ELEMENTS) {
       count_elements = DEFAULT_COUNT_OF_ELEMENETS;
     }
-    
+
     if (size_of_element < 1 ||
                  !vc_vector_realloc(v, count_elements)) {
       free(v);
@@ -78,7 +78,7 @@ vc_vector* vc_vector_create_copy(const vc_vector* vector) {
   if (!new_vector) {
     return new_vector;
   }
-  
+
   if (memcpy(vector->data,
                       new_vector->data,
                       new_vector->element_size * vector->count) == NULL) {
@@ -86,7 +86,7 @@ vc_vector* vc_vector_create_copy(const vc_vector* vector) {
     new_vector = NULL;
     return new_vector;
   }
-  
+
   new_vector->count = vector->count;
   return new_vector;
 }
@@ -95,11 +95,11 @@ void vc_vector_release(vc_vector* vector) {
   if (vector->deleter != NULL) {
     vc_vector_call_deleter_all(vector);
   }
-  
+
   if (vector->reserved_size != 0) {
     free(vector->data);
   }
-  
+
   free(vector);
 }
 
@@ -108,7 +108,7 @@ bool vc_vector_is_equals(vc_vector* vector1, vc_vector* vector2) {
   if (size_vector1 != vc_vector_size(vector2)) {
     return false;
   }
-  
+
   return memcmp(vector1->data, vector2->data, size_vector1) == 0;
 }
 
@@ -193,7 +193,7 @@ bool vc_vector_reserve_count(vc_vector* vector, size_t new_count) {
   if (new_size == vector->reserved_size) {
     return true;
   }
-  
+
   return vc_vector_realloc(vector, new_count);
 }
 
@@ -209,7 +209,7 @@ void vc_vector_clear(vc_vector* vector) {
   if (vector->deleter != NULL) {
     vc_vector_call_deleter_all(vector);
   }
-  
+
   vector->count = 0;
 }
 
@@ -219,20 +219,20 @@ bool vc_vector_insert(vc_vector* vector, size_t index, const void* value) {
       return false;
     }
   }
-  
+
   if (!memmove(vc_vector_at(vector, index + 1),
                         vc_vector_at(vector, index),
                         vector->element_size * (vector->count - index))) {
 
     return false;
   }
-  
+
   if (memcpy(vc_vector_at(vector, index),
                       value,
                       vector->element_size) == NULL) {
     return false;
   }
-  
+
   ++vector->count;
   return true;
 }
@@ -241,13 +241,13 @@ bool vc_vector_erase(vc_vector* vector, size_t index) {
   if (vector->deleter != NULL) {
     vector->deleter(vc_vector_at(vector, index));
   }
-  
+
   if (!memmove(vc_vector_at(vector, index),
                         vc_vector_at(vector, index + 1),
                         vector->element_size * (vector->count - index))) {
     return false;
   }
-  
+
   vector->count--;
   return true;
 }
@@ -256,37 +256,37 @@ bool vc_vector_erase_range(vc_vector* vector, size_t first_index, size_t last_in
   if (vector->deleter != NULL) {
     vc_vector_call_deleter(vector, first_index, last_index);
   }
-  
+
   if (!memmove(vc_vector_at(vector, first_index),
                         vc_vector_at(vector, last_index),
                         vector->element_size * (vector->count - last_index))) {
     return false;
   }
-  
+
   vector->count -= last_index - first_index;
   return true;
 }
 
 bool vc_vector_append(vc_vector* vector, const void* values, size_t count) {
   const size_t count_new = count + vc_vector_count(vector);
-  
+
   if (vc_vector_max_count(vector) < count_new) {
     size_t max_count_to_reserved = vc_vector_max_count(vector) * GROWTH_FACTOR;
     while (count_new > max_count_to_reserved) {
       max_count_to_reserved *= GROWTH_FACTOR;
     }
-    
+
     if (!vc_vector_realloc(vector, max_count_to_reserved)) {
       return false;
     }
   }
-  
+
   if (memcpy(vector->data + vector->count * vector->element_size,
                       values,
                       vector->element_size * count) == NULL) {
     return false;
   }
-  
+
   vector->count = count_new;
   return true;
 }
@@ -295,7 +295,7 @@ bool vc_vector_push_back(vc_vector* vector, const void* value) {
   if (!vc_vector_append(vector, value, 1)) {
     return false;
   }
-  
+
   return true;
 }
 
@@ -303,7 +303,7 @@ bool vc_vector_pop_back(vc_vector* vector) {
   if (vector->deleter != NULL) {
     vector->deleter(vc_vector_back(vector));
   }
-  
+
   vector->count--;
   return true;
 }
@@ -312,7 +312,7 @@ bool vc_vector_replace(vc_vector* vector, size_t index, const void* value) {
   if (vector->deleter != NULL) {
     vector->deleter(vc_vector_at(vector, index));
   }
-  
+
   return memcpy(vc_vector_at(vector, index),
                 value,
                 vector->element_size) != NULL;
@@ -322,7 +322,7 @@ bool vc_vector_replace_multiple(vc_vector* vector, size_t index, const void* val
   if (vector->deleter != NULL) {
     vc_vector_call_deleter(vector, index, index + count);
   }
-  
+
   return memcpy(vc_vector_at(vector, index),
                 values,
                 vector->element_size * count) != NULL;

--- a/vc_vector.c
+++ b/vc_vector.c
@@ -3,7 +3,7 @@
 #include <string.h>
 
 #define GROWTH_FACTOR 1.5
-#define DEFAULT_COUNT_OF_ELEMENETS 8
+#define DEFAULT_COUNT_OF_ELEMENTS 8
 #define MINIMUM_COUNT_OF_ELEMENTS 2
 
 // ----------------------------------------------------------------------------
@@ -20,7 +20,7 @@ struct vc_vector {
 
 // ----------------------------------------------------------------------------
 
-// auxillary methods
+// Auxiliary methods
 
 bool vc_vector_realloc(vc_vector* vector, size_t new_count) {
   const size_t new_size = new_count * vector->element_size;
@@ -47,7 +47,7 @@ void vc_vector_call_deleter_all(vc_vector* vector) {
 
 // ----------------------------------------------------------------------------
 
-// Contol
+// Control
 
 vc_vector* vc_vector_create(size_t count_elements, size_t size_of_element, vc_vector_deleter* deleter) {
   vc_vector* v = (vc_vector*)malloc(sizeof(vc_vector));
@@ -58,7 +58,7 @@ vc_vector* vc_vector_create(size_t count_elements, size_t size_of_element, vc_ve
     v->deleter = deleter;
 
     if (count_elements < MINIMUM_COUNT_OF_ELEMENTS) {
-      count_elements = DEFAULT_COUNT_OF_ELEMENETS;
+      count_elements = DEFAULT_COUNT_OF_ELEMENTS;
     }
 
     if (size_of_element < 1 ||
@@ -117,7 +117,7 @@ float vc_vector_get_growth_factor() {
 }
 
 size_t vc_vector_get_default_count_of_elements() {
-  return DEFAULT_COUNT_OF_ELEMENETS;
+  return DEFAULT_COUNT_OF_ELEMENTS;
 }
 
 size_t vc_vector_struct_size() {

--- a/vc_vector_test.c
+++ b/vc_vector_test.c
@@ -4,24 +4,24 @@
 #include <inttypes.h>
 #include "vc_vector.h"
 
-#define ASSERT_EQ(expected, actual)                          \
-  do {                                                       \
-    if ((expected) != (actual)) {                            \
-      fprintf(stderr,                                        \
-              "Failed line %u. Expected: %u. Actual: %u.\n", \
-              __LINE__, (int)(expected), (int)(actual));     \
-      abort();                                               \
-    }                                                        \
+#define ASSERT_EQ(expected, actual)                                          \
+  do {                                                                       \
+    if ((expected) != (actual)) {                                            \
+      fprintf(stderr,                                                        \
+              "Failed line %u. Expected: %"PRIuMAX". Actual: %"PRIuMAX".\n", \
+              __LINE__, (uintmax_t)(expected), (uintmax_t)(actual));         \
+      abort();                                                               \
+    }                                                                        \
   } while (0)
 
-#define ASSERT_NE(not_expected, actual)                         \
-  do {                                                          \
-    if ((not_expected) == (actual)) {                           \
-      fprintf(stderr,                                           \
-              "Failed line %u. Unexpected actual value: %u.\n", \
-             __LINE__, (int)(actual));                          \
-      abort();                                                  \
-    }                                                           \
+#define ASSERT_NE(not_expected, actual)                                 \
+  do {                                                                  \
+    if ((not_expected) == (actual)) {                                   \
+      fprintf(stderr,                                                   \
+              "Failed line %u. Unexpected actual value: %"PRIuMAX".\n", \
+             __LINE__, (uintmax_t)(actual));                            \
+      abort();                                                          \
+    }                                                                   \
   } while (0)
 
 #define ASSERT_TRUE(actual) ASSERT_EQ(true, (actual))

--- a/vc_vector_test.c
+++ b/vc_vector_test.c
@@ -41,6 +41,14 @@
 #define PRINT_VECTOR_INT(vector) PRINT_VECTOR(vector, int, "%d; ")
 #define PRINT_VECTOR_STR(vector) PRINT_VECTOR(vector, char *, "%s; ")
 
+char *mystrdup(const char *s) {
+  size_t size = strlen(s) + 1;
+  char *copy = malloc(size);
+  if (copy != NULL)
+    memcpy(copy, s, size);
+  return copy;
+}
+
 // ----------------------------------------------------------------------------
 
 void test_vc_vector_create() {
@@ -293,15 +301,15 @@ void test_vc_vector_with_strfreefunc() {
   ASSERT_NE(NULL, vector);
 
   char *strs[] = {
-    strdup("abcde"),
-    strdup("edcba"),
-    strdup("1234554321"),
-    strdup("!@#$%"),
-    strdup("not empty string"),
-    strdup(""),
-    strdup("Hello World"),
-    strdup("xxxxx"),
-    strdup("yyyyy")
+    mystrdup("abcde"),
+    mystrdup("edcba"),
+    mystrdup("1234554321"),
+    mystrdup("!@#$%"),
+    mystrdup("not empty string"),
+    mystrdup(""),
+    mystrdup("Hello World"),
+    mystrdup("xxxxx"),
+    mystrdup("yyyyy")
   };
 
   for (size_t i = 0; i < 3; ++i) {

--- a/vc_vector_test.c
+++ b/vc_vector_test.c
@@ -109,8 +109,10 @@ void test_vc_vector_iterators() {
   }
   
   int j = 0;
-  for (void* i = vc_vector_begin(vector); i != vc_vector_end(vector); i = vc_vector_next(vector, i)) {
-    ASSERT_EQ(j++, *(int*)i);
+  for (void* i = vc_vector_begin(vector);
+       i != vc_vector_end(vector);
+       i = vc_vector_next(vector, i), ++j) {
+    ASSERT_EQ(j, *(int*)i);
   }
   
   ASSERT_EQ(test_count_of_elements, j);

--- a/vc_vector_test.c
+++ b/vc_vector_test.c
@@ -117,7 +117,7 @@ void test_vc_vector_iterators() {
   
   const size_t test_count_of_elements = 23;
   for (int i = 0; (size_t)i < test_count_of_elements; ++i) {
-    ASSERT_EQ(true, vc_vector_push_back(vector, &i));
+    ASSERT_TRUE(vc_vector_push_back(vector, &i));
   }
   
   int j = 0;
@@ -149,36 +149,37 @@ void test_vc_vector_capacity() {
   ASSERT_NE(NULL, vector);
   
   ASSERT_EQ(0, vc_vector_count(vector));
-  ASSERT_EQ(true, vc_vector_empty(vector));
+  ASSERT_TRUE(vc_vector_empty(vector));
   ASSERT_EQ(0, vc_vector_size(vector));
   ASSERT_EQ(count_of_elements_initialized, vc_vector_max_count(vector));
   ASSERT_EQ(max_size_of_vector_initialized, vc_vector_max_size(vector));
   
   for (int i = 0; (size_t)i < count_of_elements_ended; ++i) {
-    ASSERT_EQ(true, vc_vector_push_back(vector, &i));
+    ASSERT_TRUE(vc_vector_push_back(vector, &i));
   }
   
   ASSERT_EQ(count_of_elements_ended, vc_vector_count(vector));
-  ASSERT_EQ(false, vc_vector_empty(vector));
+  ASSERT_FALSE(vc_vector_empty(vector));
   ASSERT_EQ(size_of_vector_ended, vc_vector_size(vector));
   ASSERT_EQ(max_count_of_vector_ended, vc_vector_max_count(vector));
   ASSERT_EQ(max_size_of_vector_ended, vc_vector_max_size(vector));
 
   const size_t test_reserve_count_fail = 10;
-  ASSERT_EQ(false, vc_vector_reserve_count(vector, test_reserve_count_fail));
+  ASSERT_FALSE(vc_vector_reserve_count(vector, test_reserve_count_fail));
   
+
   const size_t test_reserve_count = 35;
-  ASSERT_EQ(true, vc_vector_reserve_count(vector, test_reserve_count));
+  ASSERT_TRUE(vc_vector_reserve_count(vector, test_reserve_count));
   ASSERT_EQ(test_reserve_count, vc_vector_max_count(vector));
   ASSERT_EQ(test_reserve_count * size_of_element, vc_vector_max_size(vector));
   
   // Second time with the same value
-  ASSERT_EQ(true, vc_vector_reserve_count(vector, test_reserve_count));
+  ASSERT_TRUE(vc_vector_reserve_count(vector, test_reserve_count));
   ASSERT_EQ(test_reserve_count, vc_vector_max_count(vector));
   ASSERT_EQ(test_reserve_count * size_of_element, vc_vector_max_size(vector));
   
   const size_t test_reserve_size = 123 * size_of_element;
-  ASSERT_EQ(true, vc_vector_reserve_size(vector, test_reserve_size));
+  ASSERT_TRUE(vc_vector_reserve_size(vector, test_reserve_size));
   ASSERT_EQ(test_reserve_size / size_of_element, vc_vector_max_count(vector));
   ASSERT_EQ(test_reserve_size, vc_vector_max_size(vector));
   
@@ -209,7 +210,7 @@ void test_vc_vector_modifiers() {
   
   // Append test
   
-  ASSERT_EQ(true, vc_vector_append(vector, (void*)begin, count_of_elements));
+  ASSERT_TRUE(vc_vector_append(vector, (void*)begin, count_of_elements));
   
   ASSERT_EQ(count_of_elements, vc_vector_count(vector));
   for (int i = 0; (size_t)i < vc_vector_count(vector); ++i) {
@@ -219,15 +220,15 @@ void test_vc_vector_modifiers() {
   // Pop back test
   
   while (vc_vector_count(vector) > 0) {
-    ASSERT_EQ(true, vc_vector_pop_back(vector));
+    ASSERT_TRUE(vc_vector_pop_back(vector));
   }
   
-  ASSERT_EQ(true, vc_vector_empty(vector));
+  ASSERT_TRUE(vc_vector_empty(vector));
   
   // Push back test
   
   for (int i = 0; (size_t)i < count_of_elements; ++i) {
-    ASSERT_EQ(true, vc_vector_push_back(vector, (void*)&begin[i]));
+    ASSERT_TRUE(vc_vector_push_back(vector, (void*)&begin[i]));
   }
   
   ASSERT_EQ(count_of_elements, vc_vector_count(vector));
@@ -238,11 +239,11 @@ void test_vc_vector_modifiers() {
   // Erase test
   
   vc_vector_clear(vector);
-  ASSERT_EQ(true, vc_vector_append(vector, (void*)begin, count_of_elements));
+  ASSERT_TRUE(vc_vector_append(vector, (void*)begin, count_of_elements));
   
-  ASSERT_EQ(true, vc_vector_erase(vector, 0));
-  ASSERT_EQ(true, vc_vector_erase(vector, vc_vector_count(vector) - 1));
-  ASSERT_EQ(true, vc_vector_erase(vector, vc_vector_count(vector) / 2));
+  ASSERT_TRUE(vc_vector_erase(vector, 0));
+  ASSERT_TRUE(vc_vector_erase(vector, vc_vector_count(vector) - 1));
+  ASSERT_TRUE(vc_vector_erase(vector, vc_vector_count(vector) / 2));
   
   ASSERT_EQ(sizeof(after_deleting_some_elements) / size_of_element, vc_vector_count(vector));
   for (size_t i = 0; i < vc_vector_count(vector); ++i) {
@@ -252,11 +253,11 @@ void test_vc_vector_modifiers() {
   // Erase range test
   
   vc_vector_clear(vector);
-  ASSERT_EQ(true, vc_vector_append(vector, (void*)begin, count_of_elements));
+  ASSERT_TRUE(vc_vector_append(vector, (void*)begin, count_of_elements));
   
-  ASSERT_EQ(true, vc_vector_erase_range(vector, 0, 3));
-  ASSERT_EQ(true, vc_vector_erase_range(vector, vc_vector_count(vector) - 3, vc_vector_count(vector)));
-  ASSERT_EQ(true, vc_vector_erase_range(vector, vc_vector_count(vector) / 2 - 2, vc_vector_count(vector) / 2 + 2));
+  ASSERT_TRUE(vc_vector_erase_range(vector, 0, 3));
+  ASSERT_TRUE(vc_vector_erase_range(vector, vc_vector_count(vector) - 3, vc_vector_count(vector)));
+  ASSERT_TRUE(vc_vector_erase_range(vector, vc_vector_count(vector) / 2 - 2, vc_vector_count(vector) / 2 + 2));
   
   ASSERT_EQ(sizeof(after_deleting_some_ranges) / size_of_element, vc_vector_count(vector));
   for (size_t i = 0; i < vc_vector_count(vector); ++i) {
@@ -267,11 +268,11 @@ void test_vc_vector_modifiers() {
   
   vc_vector_clear(vector);
   for (size_t i = 1; i < count_of_elements - 1; ++i) {
-    ASSERT_EQ(true, vc_vector_insert(vector, i - 1, (void*)&begin[i]));
+    ASSERT_TRUE(vc_vector_insert(vector, i - 1, (void*)&begin[i]));
   }
   
-  ASSERT_EQ(true, vc_vector_insert(vector, 0, &begin[0]));
-  ASSERT_EQ(true, vc_vector_insert(vector, vc_vector_count(vector), &begin[count_of_elements - 1]));
+  ASSERT_TRUE(vc_vector_insert(vector, 0, &begin[0]));
+  ASSERT_TRUE(vc_vector_insert(vector, vc_vector_count(vector), &begin[count_of_elements - 1]));
   
   ASSERT_EQ(count_of_elements, vc_vector_count(vector));
   for (size_t i = 0; i < vc_vector_count(vector); ++i) {

--- a/vc_vector_test.c
+++ b/vc_vector_test.c
@@ -1,6 +1,7 @@
 #include "vc_vector_test.h"
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 #include "vc_vector.h"
 
 #define ASSERT_EQ(expected, actual) if ((expected) != (actual)) { \
@@ -61,7 +62,7 @@ void test_vc_vector_create() {
   // Creating copy of vector
   vector = vc_vector_create(0, size_of_type, NULL);
   ASSERT_NE(NULL, vector);
-  for (int i = 0; i < test_count_of_elements; ++i) {
+  for (int i = 0; (size_t)i < test_count_of_elements; ++i) {
     ASSERT_TRUE(vc_vector_push_back(vector, &i));
   }
   
@@ -103,8 +104,8 @@ void test_vc_vector_iterators() {
   vc_vector* vector = vc_vector_create(0, sizeof(int), NULL);
   ASSERT_NE(NULL, vector);
   
-  const int test_count_of_elements = 23;
-  for (int i = 0; i < test_count_of_elements; ++i) {
+  const size_t test_count_of_elements = 23;
+  for (int i = 0; (size_t)i < test_count_of_elements; ++i) {
     ASSERT_EQ(true, vc_vector_push_back(vector, &i));
   }
   
@@ -115,23 +116,23 @@ void test_vc_vector_iterators() {
     ASSERT_EQ(j, *(int*)i);
   }
   
-  ASSERT_EQ(test_count_of_elements, j);
+  ASSERT_EQ(test_count_of_elements, (size_t)j);
   vc_vector_release(vector);
   
   printf("%s passed.\n", __PRETTY_FUNCTION__);
 }
 
 void test_vc_vector_capacity() {
-  const int size_of_element = sizeof(int);
+  const size_t size_of_element = sizeof(int);
   const float growth_factor = vc_vector_get_growth_factor();
   ASSERT_EQ(1.5, growth_factor);
   
-  const int count_of_elements_initialized = 22;
-  const int max_size_of_vector_initialized = count_of_elements_initialized * size_of_element;
-  const int count_of_elements_ended = 23;
-  const int size_of_vector_ended = count_of_elements_ended * size_of_element;
-  const int max_count_of_vector_ended = count_of_elements_initialized * growth_factor;
-  const int max_size_of_vector_ended = max_count_of_vector_ended * size_of_element;
+  const size_t count_of_elements_initialized = 22;
+  const size_t max_size_of_vector_initialized = count_of_elements_initialized * size_of_element;
+  const size_t count_of_elements_ended = 23;
+  const size_t size_of_vector_ended = count_of_elements_ended * size_of_element;
+  const size_t max_count_of_vector_ended = count_of_elements_initialized * growth_factor;
+  const size_t max_size_of_vector_ended = max_count_of_vector_ended * size_of_element;
   
   vc_vector* vector = vc_vector_create(count_of_elements_initialized, size_of_element, NULL);
   ASSERT_NE(NULL, vector);
@@ -142,7 +143,7 @@ void test_vc_vector_capacity() {
   ASSERT_EQ(count_of_elements_initialized, vc_vector_max_count(vector));
   ASSERT_EQ(max_size_of_vector_initialized, vc_vector_max_size(vector));
   
-  for (int i = 0; i < count_of_elements_ended; ++i) {
+  for (int i = 0; (size_t)i < count_of_elements_ended; ++i) {
     ASSERT_EQ(true, vc_vector_push_back(vector, &i));
   }
   
@@ -152,10 +153,10 @@ void test_vc_vector_capacity() {
   ASSERT_EQ(max_count_of_vector_ended, vc_vector_max_count(vector));
   ASSERT_EQ(max_size_of_vector_ended, vc_vector_max_size(vector));
 
-  const int test_reserve_count_fail = 10;
+  const size_t test_reserve_count_fail = 10;
   ASSERT_EQ(false, vc_vector_reserve_count(vector, test_reserve_count_fail));
   
-  const int test_reserve_count = 35;
+  const size_t test_reserve_count = 35;
   ASSERT_EQ(true, vc_vector_reserve_count(vector, test_reserve_count));
   ASSERT_EQ(test_reserve_count, vc_vector_max_count(vector));
   ASSERT_EQ(test_reserve_count * size_of_element, vc_vector_max_size(vector));
@@ -165,7 +166,7 @@ void test_vc_vector_capacity() {
   ASSERT_EQ(test_reserve_count, vc_vector_max_count(vector));
   ASSERT_EQ(test_reserve_count * size_of_element, vc_vector_max_size(vector));
   
-  const int test_reserve_size = 123 * size_of_element;
+  const size_t test_reserve_size = 123 * size_of_element;
   ASSERT_EQ(true, vc_vector_reserve_size(vector, test_reserve_size));
   ASSERT_EQ(test_reserve_size / size_of_element, vc_vector_max_count(vector));
   ASSERT_EQ(test_reserve_size, vc_vector_max_size(vector));
@@ -179,8 +180,8 @@ void test_vc_vector_modifiers() {
   const int begin[] = {
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
   };
-  const int size_of_element = sizeof(begin[0]);
-  const int count_of_elements = sizeof(begin) / size_of_element;
+  const size_t size_of_element = sizeof(begin[0]);
+  const size_t count_of_elements = sizeof(begin) / size_of_element;
   
   // After deleting first, last and one middle elements
   const int after_deleting_some_elements[] = {
@@ -200,7 +201,7 @@ void test_vc_vector_modifiers() {
   ASSERT_EQ(true, vc_vector_append(vector, (void*)begin, count_of_elements));
   
   ASSERT_EQ(count_of_elements, vc_vector_count(vector));
-  for (int i = 0; i < vc_vector_count(vector); ++i) {
+  for (int i = 0; (size_t)i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(begin[i], *(int*)vc_vector_at(vector, i));
   }
   
@@ -214,12 +215,12 @@ void test_vc_vector_modifiers() {
   
   // Push back test
   
-  for (int i = 0; i < count_of_elements; ++i) {
+  for (int i = 0; (size_t)i < count_of_elements; ++i) {
     ASSERT_EQ(true, vc_vector_push_back(vector, (void*)&begin[i]));
   }
   
   ASSERT_EQ(count_of_elements, vc_vector_count(vector));
-  for (int i = 0; i < vc_vector_count(vector); ++i) {
+  for (int i = 0; (size_t)i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(begin[i], *(int*)vc_vector_at(vector, i));
   }
   
@@ -233,7 +234,7 @@ void test_vc_vector_modifiers() {
   ASSERT_EQ(true, vc_vector_erase(vector, vc_vector_count(vector) / 2));
   
   ASSERT_EQ(sizeof(after_deleting_some_elements) / size_of_element, vc_vector_count(vector));
-  for (int i = 0; i < vc_vector_count(vector); ++i) {
+  for (size_t i = 0; i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(after_deleting_some_elements[i], *(int*)vc_vector_at(vector, i));
   }
   
@@ -247,14 +248,14 @@ void test_vc_vector_modifiers() {
   ASSERT_EQ(true, vc_vector_erase_range(vector, vc_vector_count(vector) / 2 - 2, vc_vector_count(vector) / 2 + 2));
   
   ASSERT_EQ(sizeof(after_deleting_some_ranges) / size_of_element, vc_vector_count(vector));
-  for (int i = 0; i < vc_vector_count(vector); ++i) {
+  for (size_t i = 0; i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(after_deleting_some_ranges[i], *(int*)vc_vector_at(vector, i));
   }
   
   // Insert test
   
   vc_vector_clear(vector);
-  for (int i = 1; i < count_of_elements - 1; ++i) {
+  for (size_t i = 1; i < count_of_elements - 1; ++i) {
     ASSERT_EQ(true, vc_vector_insert(vector, i - 1, (void*)&begin[i]));
   }
   
@@ -262,7 +263,7 @@ void test_vc_vector_modifiers() {
   ASSERT_EQ(true, vc_vector_insert(vector, vc_vector_count(vector), &begin[count_of_elements - 1]));
   
   ASSERT_EQ(count_of_elements, vc_vector_count(vector));
-  for (int i = 0; i < vc_vector_count(vector); ++i) {
+  for (size_t i = 0; i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(begin[i], *(int*)vc_vector_at(vector, i));
   }
   
@@ -292,13 +293,13 @@ void test_vc_vector_with_strfreefunc() {
     strdup("yyyyy")
   };
   
-  for (int i = 0; i < 3; ++i) {
+  for (size_t i = 0; i < 3; ++i) {
     ASSERT_TRUE(vc_vector_push_back(vector, &strs[i]));
   }
   
   ASSERT_EQ(3, vc_vector_count(vector));
 
-  for (int i = 3; i < 6; ++i) {
+  for (size_t i = 3; i < 6; ++i) {
     ASSERT_TRUE(vc_vector_insert(vector, i, &strs[i]));
   }
   
@@ -306,7 +307,7 @@ void test_vc_vector_with_strfreefunc() {
   vc_vector_clear(vector); // strs[0-6] were freed
   ASSERT_EQ(0, vc_vector_count(vector));
   
-  for (int i = 6; i < 9; ++i) {
+  for (size_t i = 6; i < 9; ++i) {
     ASSERT_TRUE(vc_vector_push_back(vector, &strs[i]));
   }
   

--- a/vc_vector_test.c
+++ b/vc_vector_test.c
@@ -4,31 +4,42 @@
 #include <inttypes.h>
 #include "vc_vector.h"
 
-#define ASSERT_EQ(expected, actual) if ((expected) != (actual)) { \
-                                      printf("Failed passing line %u. Expected: %u. Actual: %u.\n", \
-                                             __LINE__, (int)(expected), (int)(actual)); \
-                                      abort(); \
-                                    }
+#define ASSERT_EQ(expected, actual)                          \
+  do {                                                       \
+    if ((expected) != (actual)) {                            \
+      fprintf(stderr,                                        \
+              "Failed line %u. Expected: %u. Actual: %u.\n", \
+              __LINE__, (int)(expected), (int)(actual));     \
+      abort();                                               \
+    }                                                        \
+  } while (0)
 
-#define ASSERT_NE(not_expected, actual) if ((not_expected) == (actual)) { \
-                                          printf("Failed passing line %u. Non expected actual value: %u.\n", \
-                                                 __LINE__, (int)(actual)); \
-                                          abort(); \
-                                        }
+#define ASSERT_NE(not_expected, actual)                         \
+  do {                                                          \
+    if ((not_expected) == (actual)) {                           \
+      fprintf(stderr,                                           \
+              "Failed line %u. Unexpected actual value: %u.\n", \
+             __LINE__, (int)(actual));                          \
+      abort();                                                  \
+    }                                                           \
+  } while (0)
 
-#define ASSERT_TRUE(actual) ASSERT_EQ(true, (actual));
+#define ASSERT_TRUE(actual) ASSERT_EQ(true, (actual))
 
-#define ASSERT_FALSE(actual) ASSERT_EQ(false, (actual));
+#define ASSERT_FALSE(actual) ASSERT_EQ(false, (actual))
 
-#define PRINT_VECTOR(vector, type, format) for (void* i = vc_vector_begin(vector); \
-                                                      i != vc_vector_end(vector); \
-                                                      i = vc_vector_next(vector, i)) { \
-                                                  printf(format, *(type*)i); \
-                                           } \
-                                           printf("\n");
+#define PRINT_VECTOR(vector, type, format)   \
+  do {                                       \
+    for (void* i = vc_vector_begin(vector);  \
+         i != vc_vector_end(vector);         \
+         i = vc_vector_next(vector, i)) {    \
+      fprintf(stderr, format, *(type*)i);    \
+    }                                        \
+    fprintf(stderr, "\n");                   \
+  } while (0)
 
 #define PRINT_VECTOR_INT(vector) PRINT_VECTOR(vector, int, "%u; ")
-#define PRINT_VECTOR_STR(vector) PRINT_VECTOR(vector, char *, "%s; ");
+#define PRINT_VECTOR_STR(vector) PRINT_VECTOR(vector, char *, "%s; ")
 
 // ----------------------------------------------------------------------------
 

--- a/vc_vector_test.c
+++ b/vc_vector_test.c
@@ -209,10 +209,10 @@ void test_vc_vector_modifiers() {
 
   // Append test
 
-  ASSERT_TRUE(vc_vector_append(vector, (void*)begin, count_of_elements));
+  ASSERT_TRUE(vc_vector_append(vector, begin, count_of_elements));
 
   ASSERT_EQ(count_of_elements, vc_vector_count(vector));
-  for (int i = 0; (size_t)i < vc_vector_count(vector); ++i) {
+  for (size_t i = 0; i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(begin[i], *(int*)vc_vector_at(vector, i));
   }
 
@@ -226,19 +226,19 @@ void test_vc_vector_modifiers() {
 
   // Push back test
 
-  for (int i = 0; (size_t)i < count_of_elements; ++i) {
-    ASSERT_TRUE(vc_vector_push_back(vector, (void*)&begin[i]));
+  for (size_t i = 0; i < count_of_elements; ++i) {
+    ASSERT_TRUE(vc_vector_push_back(vector, &begin[i]));
   }
 
   ASSERT_EQ(count_of_elements, vc_vector_count(vector));
-  for (int i = 0; (size_t)i < vc_vector_count(vector); ++i) {
+  for (size_t i = 0; i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(begin[i], *(int*)vc_vector_at(vector, i));
   }
 
   // Erase test
 
   vc_vector_clear(vector);
-  ASSERT_TRUE(vc_vector_append(vector, (void*)begin, count_of_elements));
+  ASSERT_TRUE(vc_vector_append(vector, begin, count_of_elements));
 
   ASSERT_TRUE(vc_vector_erase(vector, 0));
   ASSERT_TRUE(vc_vector_erase(vector, vc_vector_count(vector) - 1));
@@ -252,7 +252,7 @@ void test_vc_vector_modifiers() {
   // Erase range test
 
   vc_vector_clear(vector);
-  ASSERT_TRUE(vc_vector_append(vector, (void*)begin, count_of_elements));
+  ASSERT_TRUE(vc_vector_append(vector, begin, count_of_elements));
 
   ASSERT_TRUE(vc_vector_erase_range(vector, 0, 3));
   ASSERT_TRUE(vc_vector_erase_range(vector, vc_vector_count(vector) - 3, vc_vector_count(vector)));
@@ -267,7 +267,7 @@ void test_vc_vector_modifiers() {
 
   vc_vector_clear(vector);
   for (size_t i = 1; i < count_of_elements - 1; ++i) {
-    ASSERT_TRUE(vc_vector_insert(vector, i - 1, (void*)&begin[i]));
+    ASSERT_TRUE(vc_vector_insert(vector, i - 1, &begin[i]));
   }
 
   ASSERT_TRUE(vc_vector_insert(vector, 0, &begin[0]));

--- a/vc_vector_test.c
+++ b/vc_vector_test.c
@@ -84,7 +84,7 @@ void test_vc_vector_create() {
   vc_vector_release(vector_copy);
   vc_vector_release(vector);
 
-  printf("%s passed.\n", __PRETTY_FUNCTION__);
+  printf("%s passed.\n", __func__);
 }
 
 void test_vc_vector_element_access() {
@@ -108,7 +108,7 @@ void test_vc_vector_element_access() {
 
   vc_vector_release(vector);
 
-  printf("%s passed.\n", __PRETTY_FUNCTION__);
+  printf("%s passed.\n", __func__);
 }
 
 void test_vc_vector_iterators() {
@@ -130,7 +130,7 @@ void test_vc_vector_iterators() {
   ASSERT_EQ(test_count_of_elements, (size_t)j);
   vc_vector_release(vector);
 
-  printf("%s passed.\n", __PRETTY_FUNCTION__);
+  printf("%s passed.\n", __func__);
 }
 
 void test_vc_vector_capacity() {
@@ -184,7 +184,7 @@ void test_vc_vector_capacity() {
 
   vc_vector_release(vector);
 
-  printf("%s passed.\n", __PRETTY_FUNCTION__);
+  printf("%s passed.\n", __func__);
 }
 
 void test_vc_vector_modifiers() {
@@ -280,7 +280,7 @@ void test_vc_vector_modifiers() {
 
   vc_vector_release(vector);
 
-  printf("%s passed.\n", __PRETTY_FUNCTION__);
+  printf("%s passed.\n", __func__);
 }
 
 void test_vc_vector_strfreefunc(void *data) {
@@ -326,7 +326,7 @@ void test_vc_vector_with_strfreefunc() {
 
   vc_vector_release(vector);
 
-  printf("%s passed.\n", __PRETTY_FUNCTION__);
+  printf("%s passed.\n", __func__);
 }
 
 void vc_vector_run_tests() {

--- a/vc_vector_test.c
+++ b/vc_vector_test.c
@@ -38,7 +38,7 @@
     fprintf(stderr, "\n");                   \
   } while (0)
 
-#define PRINT_VECTOR_INT(vector) PRINT_VECTOR(vector, int, "%u; ")
+#define PRINT_VECTOR_INT(vector) PRINT_VECTOR(vector, int, "%d; ")
 #define PRINT_VECTOR_STR(vector) PRINT_VECTOR(vector, char *, "%s; ")
 
 // ----------------------------------------------------------------------------

--- a/vc_vector_test.c
+++ b/vc_vector_test.c
@@ -46,7 +46,7 @@
 void test_vc_vector_create() {
   const size_t size_of_type = sizeof(int);
   const size_t default_count_of_elements = vc_vector_get_default_count_of_elements();
-  
+
   // Creating vector with default count of elements
   vc_vector* vector = vc_vector_create(0, size_of_type, NULL);
   ASSERT_NE(NULL, vector);
@@ -55,7 +55,7 @@ void test_vc_vector_create() {
   ASSERT_EQ(default_count_of_elements, vc_vector_max_count(vector));
   ASSERT_EQ(size_of_type * default_count_of_elements, vc_vector_max_size(vector));
   vc_vector_release(vector);
-  
+
   // Creating vector with custom count of elements
   const size_t test_count_of_elements = 7;
   vector = vc_vector_create(test_count_of_elements, size_of_type, NULL);
@@ -65,25 +65,25 @@ void test_vc_vector_create() {
   ASSERT_EQ(test_count_of_elements, vc_vector_max_count(vector));
   ASSERT_EQ(size_of_type * test_count_of_elements, vc_vector_max_size(vector));
   vc_vector_release(vector);
-  
+
   // Creating vector with zero size of single element
   vector = vc_vector_create(0, 0, NULL);
   ASSERT_EQ(NULL, vector);
-  
+
   // Creating copy of vector
   vector = vc_vector_create(0, size_of_type, NULL);
   ASSERT_NE(NULL, vector);
   for (int i = 0; (size_t)i < test_count_of_elements; ++i) {
     ASSERT_TRUE(vc_vector_push_back(vector, &i));
   }
-  
+
   vc_vector* vector_copy = vc_vector_create_copy(vector);
   ASSERT_NE(NULL, vector_copy);
   ASSERT_TRUE(vc_vector_is_equals(vector, vector_copy));
-  
+
   vc_vector_release(vector_copy);
   vc_vector_release(vector);
-  
+
   printf("%s passed.\n", __PRETTY_FUNCTION__);
 }
 
@@ -91,45 +91,45 @@ void test_vc_vector_element_access() {
   const int test_num_start = 18;
   const int test_num_end = 36;
   const size_t size_of_type = sizeof(test_num_start);
-  
+
   vc_vector* vector = vc_vector_create(0, size_of_type, NULL);
   ASSERT_NE(0, vector);
   for (int i = test_num_start; i <= test_num_end; ++i) {
     ASSERT_TRUE(vc_vector_push_back(vector, &i));
   }
-  
+
   ASSERT_EQ(test_num_start, *(int*)vc_vector_front(vector));
   ASSERT_EQ(test_num_start, *(int*)vc_vector_data(vector));
   ASSERT_EQ(test_num_end, *(int*)vc_vector_back(vector));
-  
+
   for (int i = test_num_start, j = 0; i <= test_num_end; ++i, ++j) {
     ASSERT_EQ(i, *(int*)vc_vector_at(vector, j));
   }
-  
+
   vc_vector_release(vector);
-  
+
   printf("%s passed.\n", __PRETTY_FUNCTION__);
 }
 
 void test_vc_vector_iterators() {
   vc_vector* vector = vc_vector_create(0, sizeof(int), NULL);
   ASSERT_NE(NULL, vector);
-  
+
   const size_t test_count_of_elements = 23;
   for (int i = 0; (size_t)i < test_count_of_elements; ++i) {
     ASSERT_TRUE(vc_vector_push_back(vector, &i));
   }
-  
+
   int j = 0;
   for (void* i = vc_vector_begin(vector);
        i != vc_vector_end(vector);
        i = vc_vector_next(vector, i), ++j) {
     ASSERT_EQ(j, *(int*)i);
   }
-  
+
   ASSERT_EQ(test_count_of_elements, (size_t)j);
   vc_vector_release(vector);
-  
+
   printf("%s passed.\n", __PRETTY_FUNCTION__);
 }
 
@@ -137,27 +137,27 @@ void test_vc_vector_capacity() {
   const size_t size_of_element = sizeof(int);
   const float growth_factor = vc_vector_get_growth_factor();
   ASSERT_EQ(1.5, growth_factor);
-  
+
   const size_t count_of_elements_initialized = 22;
   const size_t max_size_of_vector_initialized = count_of_elements_initialized * size_of_element;
   const size_t count_of_elements_ended = 23;
   const size_t size_of_vector_ended = count_of_elements_ended * size_of_element;
   const size_t max_count_of_vector_ended = count_of_elements_initialized * growth_factor;
   const size_t max_size_of_vector_ended = max_count_of_vector_ended * size_of_element;
-  
+
   vc_vector* vector = vc_vector_create(count_of_elements_initialized, size_of_element, NULL);
   ASSERT_NE(NULL, vector);
-  
+
   ASSERT_EQ(0, vc_vector_count(vector));
   ASSERT_TRUE(vc_vector_empty(vector));
   ASSERT_EQ(0, vc_vector_size(vector));
   ASSERT_EQ(count_of_elements_initialized, vc_vector_max_count(vector));
   ASSERT_EQ(max_size_of_vector_initialized, vc_vector_max_size(vector));
-  
+
   for (int i = 0; (size_t)i < count_of_elements_ended; ++i) {
     ASSERT_TRUE(vc_vector_push_back(vector, &i));
   }
-  
+
   ASSERT_EQ(count_of_elements_ended, vc_vector_count(vector));
   ASSERT_FALSE(vc_vector_empty(vector));
   ASSERT_EQ(size_of_vector_ended, vc_vector_size(vector));
@@ -166,25 +166,24 @@ void test_vc_vector_capacity() {
 
   const size_t test_reserve_count_fail = 10;
   ASSERT_FALSE(vc_vector_reserve_count(vector, test_reserve_count_fail));
-  
 
   const size_t test_reserve_count = 35;
   ASSERT_TRUE(vc_vector_reserve_count(vector, test_reserve_count));
   ASSERT_EQ(test_reserve_count, vc_vector_max_count(vector));
   ASSERT_EQ(test_reserve_count * size_of_element, vc_vector_max_size(vector));
-  
+
   // Second time with the same value
   ASSERT_TRUE(vc_vector_reserve_count(vector, test_reserve_count));
   ASSERT_EQ(test_reserve_count, vc_vector_max_count(vector));
   ASSERT_EQ(test_reserve_count * size_of_element, vc_vector_max_size(vector));
-  
+
   const size_t test_reserve_size = 123 * size_of_element;
   ASSERT_TRUE(vc_vector_reserve_size(vector, test_reserve_size));
   ASSERT_EQ(test_reserve_size / size_of_element, vc_vector_max_count(vector));
   ASSERT_EQ(test_reserve_size, vc_vector_max_size(vector));
-  
+
   vc_vector_release(vector);
-  
+
   printf("%s passed.\n", __PRETTY_FUNCTION__);
 }
 
@@ -194,93 +193,93 @@ void test_vc_vector_modifiers() {
   };
   const size_t size_of_element = sizeof(begin[0]);
   const size_t count_of_elements = sizeof(begin) / size_of_element;
-  
+
   // After deleting first, last and one middle elements
   const int after_deleting_some_elements[] = {
     /* 1, */ 2, 3, 4, 5, 6, 7, 8, 9, 10, /* 11, */ 12, 13, 14, 15, 16, 17, 18, 19, /* 20 */
   };
-  
+
   // After deleting first 3 elemets from begin, 4 from middle and 3 from end
   const int after_deleting_some_ranges[] = {
     /* 1, 2, 3, */ 4, 5, 6, 7, 8, /* 9, 10, 11, 12, */ 13, 14, 15, 16, 17, /* 18, 19, 20 */
   };
-  
+
   vc_vector* vector = vc_vector_create(0, size_of_element, NULL);
   ASSERT_NE(NULL, vector);
-  
+
   // Append test
-  
+
   ASSERT_TRUE(vc_vector_append(vector, (void*)begin, count_of_elements));
-  
+
   ASSERT_EQ(count_of_elements, vc_vector_count(vector));
   for (int i = 0; (size_t)i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(begin[i], *(int*)vc_vector_at(vector, i));
   }
-  
+
   // Pop back test
-  
+
   while (vc_vector_count(vector) > 0) {
     ASSERT_TRUE(vc_vector_pop_back(vector));
   }
-  
+
   ASSERT_TRUE(vc_vector_empty(vector));
-  
+
   // Push back test
-  
+
   for (int i = 0; (size_t)i < count_of_elements; ++i) {
     ASSERT_TRUE(vc_vector_push_back(vector, (void*)&begin[i]));
   }
-  
+
   ASSERT_EQ(count_of_elements, vc_vector_count(vector));
   for (int i = 0; (size_t)i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(begin[i], *(int*)vc_vector_at(vector, i));
   }
-  
+
   // Erase test
-  
+
   vc_vector_clear(vector);
   ASSERT_TRUE(vc_vector_append(vector, (void*)begin, count_of_elements));
-  
+
   ASSERT_TRUE(vc_vector_erase(vector, 0));
   ASSERT_TRUE(vc_vector_erase(vector, vc_vector_count(vector) - 1));
   ASSERT_TRUE(vc_vector_erase(vector, vc_vector_count(vector) / 2));
-  
+
   ASSERT_EQ(sizeof(after_deleting_some_elements) / size_of_element, vc_vector_count(vector));
   for (size_t i = 0; i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(after_deleting_some_elements[i], *(int*)vc_vector_at(vector, i));
   }
-  
+
   // Erase range test
-  
+
   vc_vector_clear(vector);
   ASSERT_TRUE(vc_vector_append(vector, (void*)begin, count_of_elements));
-  
+
   ASSERT_TRUE(vc_vector_erase_range(vector, 0, 3));
   ASSERT_TRUE(vc_vector_erase_range(vector, vc_vector_count(vector) - 3, vc_vector_count(vector)));
   ASSERT_TRUE(vc_vector_erase_range(vector, vc_vector_count(vector) / 2 - 2, vc_vector_count(vector) / 2 + 2));
-  
+
   ASSERT_EQ(sizeof(after_deleting_some_ranges) / size_of_element, vc_vector_count(vector));
   for (size_t i = 0; i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(after_deleting_some_ranges[i], *(int*)vc_vector_at(vector, i));
   }
-  
+
   // Insert test
-  
+
   vc_vector_clear(vector);
   for (size_t i = 1; i < count_of_elements - 1; ++i) {
     ASSERT_TRUE(vc_vector_insert(vector, i - 1, (void*)&begin[i]));
   }
-  
+
   ASSERT_TRUE(vc_vector_insert(vector, 0, &begin[0]));
   ASSERT_TRUE(vc_vector_insert(vector, vc_vector_count(vector), &begin[count_of_elements - 1]));
-  
+
   ASSERT_EQ(count_of_elements, vc_vector_count(vector));
   for (size_t i = 0; i < vc_vector_count(vector); ++i) {
     ASSERT_EQ(begin[i], *(int*)vc_vector_at(vector, i));
   }
-  
+
   vc_vector_release(vector);
-  
+
   printf("%s passed.\n", __PRETTY_FUNCTION__);
 }
 
@@ -304,29 +303,29 @@ void test_vc_vector_with_strfreefunc() {
     strdup("xxxxx"),
     strdup("yyyyy")
   };
-  
+
   for (size_t i = 0; i < 3; ++i) {
     ASSERT_TRUE(vc_vector_push_back(vector, &strs[i]));
   }
-  
+
   ASSERT_EQ(3, vc_vector_count(vector));
 
   for (size_t i = 3; i < 6; ++i) {
     ASSERT_TRUE(vc_vector_insert(vector, i, &strs[i]));
   }
-  
+
   ASSERT_EQ(6, vc_vector_count(vector));
   vc_vector_clear(vector); // strs[0-6] were freed
   ASSERT_EQ(0, vc_vector_count(vector));
-  
+
   for (size_t i = 6; i < 9; ++i) {
     ASSERT_TRUE(vc_vector_push_back(vector, &strs[i]));
   }
-  
+
   ASSERT_EQ(3, vc_vector_count(vector));
 
   vc_vector_release(vector);
-  
+
   printf("%s passed.\n", __PRETTY_FUNCTION__);
 }
 


### PR DESCRIPTION
There was a compile warning about void pointer arithmetic in the library code.
I also took the occasion to fix warnings in the tests and to write a Makefile to run the tests more easily.
* `$ make` compiles a shared object `build/libvc-vector.so`.
* `$ make test` compiles and runs the tests, in `build/`.

Travis CI will run `make && make test` to insure the library compiles on its own and all tests pass.

All is compiled with very strict options `-std=c99 -Wall -Wextra -Wpedantic -Werror`.

https://travis-ci.org/augfab/vc_vector/builds/337187976