### PR TITLE
Harden vc_vector boundary checks and copy behavior

### DIFF
--- a/vc_vector.h
+++ b/vc_vector.h
@@ -21,7 +21,7 @@ vc_vector* vc_vector_create_copy(const vc_vector* vector);
 void vc_vector_release(vc_vector* vector);
 
 // Compares vector content
-bool vc_vector_is_equals(vc_vector* vector1, vc_vector* vector2);
+bool vc_vector_is_equals(const vc_vector* vector1, const vc_vector* vector2);
 
 // Returns constant value of the vector growth factor.
 float vc_vector_get_growth_factor();

--- a/vc_vector_test.c
+++ b/vc_vector_test.c
@@ -337,6 +337,35 @@ void test_vc_vector_with_strfreefunc() {
   printf("%s passed.\n", __func__);
 }
 
+void test_vc_vector_defensive_checks() {
+  vc_vector* vector = vc_vector_create(0, sizeof(int), NULL);
+  ASSERT_NE(NULL, vector);
+
+  ASSERT_FALSE(vc_vector_pop_back(vector));
+  ASSERT_FALSE(vc_vector_erase(vector, 0));
+  ASSERT_FALSE(vc_vector_insert(vector, 1, &(int){1}));
+  ASSERT_FALSE(vc_vector_append(vector, NULL, 1));
+
+  for (int i = 0; i < 4; ++i) {
+    ASSERT_TRUE(vc_vector_push_back(vector, &i));
+  }
+
+  ASSERT_FALSE(vc_vector_erase_range(vector, 3, 2));
+  ASSERT_FALSE(vc_vector_erase_range(vector, 0, vc_vector_count(vector) + 1));
+  ASSERT_FALSE(vc_vector_replace(vector, vc_vector_count(vector), &(int){5}));
+  ASSERT_FALSE(vc_vector_replace(vector, 0, NULL));
+  ASSERT_FALSE(vc_vector_replace_multiple(vector, 1, &(int){7}, vc_vector_count(vector)));
+
+  vc_vector* copy = vc_vector_create_copy(vector);
+  ASSERT_NE(NULL, copy);
+  ASSERT_TRUE(vc_vector_is_equals(vector, copy));
+
+  vc_vector_release(copy);
+  vc_vector_release(vector);
+
+  printf("%s passed.\n", __func__);
+}
+
 void vc_vector_run_tests() {
   test_vc_vector_create();
   test_vc_vector_element_access();
@@ -344,6 +373,7 @@ void vc_vector_run_tests() {
   test_vc_vector_capacity();
   test_vc_vector_modifiers();
   test_vc_vector_with_strfreefunc();
+  test_vc_vector_defensive_checks();
 }
 
 int main() {


### PR DESCRIPTION
### Motivation
- Prevent undefined behaviour and integer overflow during capacity calculations and reallocations by adding defensive validation. 
- Fix critical copy semantics and null/empty-vector handling to avoid division-by-zero and reversed `memcpy` scenarios. 
- Reduce API footgun risk by validating inputs for mutating operations and hiding internal helpers from the public symbol table.

### Description
- Added `#include <stdint.h>` and use `SIZE_MAX` checks to protect against arithmetic overflow in allocation and reserve logic. 
- Made internal helpers (`vc_vector_realloc`, `vc_vector_call_deleter`, `vc_vector_call_deleter_all`) `static` to avoid leaking private symbols. 
- Reworked `vc_vector_create`, `vc_vector_create_copy`, and `vc_vector_release` for null/empty safety and correct allocation semantics. 
- Added boundary and argument validation to `insert`, `erase`, `erase_range`, `append`, `pop_back`, `replace`, and `replace_multiple`, and changed `vc_vector_is_equals` signature to accept `const` pointers. 
- Extended test-suite with `test_vc_vector_defensive_checks` covering invalid/edge inputs and updated `vc_vector_test.c` accordingly.

### Testing
- Running `make test` initially exposed a compile error related to `SIZE_MAX`, which was fixed by adding the proper include; this was part of automated iteration. 
- Final `make test` executed the full test-suite (including the new defensive checks) and completed successfully with all tests passing under the project `Makefile` configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a16df6e8788323bf85cf344f26462a)